### PR TITLE
Top PyPI Packages: Use 30-days data, 365 is no longer available

### DIFF
--- a/pypi_client/repo.py
+++ b/pypi_client/repo.py
@@ -21,7 +21,7 @@ def get_all_pkg_names() -> Iterator[str]:
 @cache.memoize()
 def get_top_popular_pkg_names() -> Set[str]:
     logging.debug('get_top_popular_pkg_names')
-    response = requests.get('https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json')
+    response = requests.get('https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json')
     response.raise_for_status()
     return {r['project'] for r in response.json().get('rows', [])}
 


### PR DESCRIPTION
I needed to remove the 365-day data from https://hugovk.github.io/top-pypi-packages/ because it was using more quota than available, so let's use the 30-day one instead.

Re: https://github.com/hugovk/top-pypi-packages/pull/21, https://github.com/hugovk/top-pypi-packages/pull/20, https://github.com/hugovk/top-pypi-packages/issues/19.
